### PR TITLE
Addressing other Med's comments

### DIFF
--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -93,7 +93,7 @@ The DNS64-based mechanism of [RFC7050] should be employed only when RA-based PRE
 DNS64: a mechanism for synthesizing AAAA records from A records, defined in [RFC6147].
 
 NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC7915]. NAT64 translators can operate in stateful ([RFC6144]) or stateless mode.
-This document uses "NAT64" as a generalized term for a translator which uses the algorith defined in [RFC7915] and operates within a framework for IPv4/IPv6 translation described in [RFC6144].
+This document uses "NAT64" as a generalized term for a translator which uses the stateless IP/ICMP translation algorithm defined in [RFC7915] and operates within a framework for IPv4/IPv6 translation described in [RFC6144].
 
 PREF64 (or Pref64::/n, or NAT64 prefix): An IPv6 prefix used for IPv6 address synthesis and for network addresses and protocols translation from IPv6 clients to IPv4 servers using the algorithm defined in [RFC6052].
 

--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -88,11 +88,12 @@ Due to fundamental shortcomings of the [RFC7050] mechanism ({{issues}}), [RFC878
 Implementations should strive for consistent PREF64 acquisition methods.
 The DNS64-based mechanism of [RFC7050] should be employed only when RA-based PREF64 delivery is unavailable, or as a fallback for legacy systems incapable of processing the PREF64 RA Option.
 
-# Conventions and Definitions
+# Terminology
 
 DNS64: a mechanism for synthesizing AAAA records from A records, defined in [RFC6147].
 
-NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC7915]. NAT64 translators can operate in stateless or stateful mode ([RFC6144]).
+NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC7915]. NAT64 translators can operate in stateful ([RFC6144]) or stateless mode. 
+This document uses "NAT64" as a generalized term for a translator which uses the algorith defined in [RFC7915] and operates within a framework for IPv4/IPv6 translation described in [RFC6144].
 
 PREF64 (or Pref64::/n, or NAT64 prefix): An IPv6 prefix used for IPv6 address synthesis and for network addresses and protocols translation from IPv6 clients to IPv4 servers using the algorithm defined in [RFC6052].
 

--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -121,8 +121,8 @@ VPN applications may override the endpoint's DNS configuration, for example, by 
 These enterprise DNS servers typically lack DNS64 functionality and therefore cannot provide information about the PREF64 used within the local network.
 Consequently, this prevents the endpoint from discovering the necessary PREF64, negatively impacting its connectivity on IPv6-only networks.
 
-If both the network-provided DNS64 and the endpoint's resolver happen to utilize the WKP, the endpoint might, by pure coincidence, use a PREF64 that's valid for the current network.
-However, if the endpoint changes its network attachment, it can't detect if the new network lacks NAT64 entirely or uses a different NSP.
+If both the network-provided DNS64 and the endpoint's resolver happen to utilize the Well-Known Prefix (64:ff9b::/96, [RFC6052]), the endpoint would discover a PREF64 that's valid for the current network.
+However, if the endpoint changes its network attachment, it can't detect if the new network lacks NAT64 entirely or uses a network-specific NAT64 prefix (NSP, [RFC6144]).
 
 ## Network Stack Initialization Delay
 

--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -92,7 +92,7 @@ The DNS64-based mechanism of [RFC7050] should be employed only when RA-based PRE
 
 DNS64: a mechanism for synthesizing AAAA records from A records, defined in [RFC6147].
 
-NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC7915]. NAT64 translators can operate in stateful ([RFC6144]) or stateless mode. 
+NAT64: a mechanism for translating IPv6 packets to IPv4 packets and vice versa.  The translation is done by translating the packet headers according to the IP/ICMP Translation Algorithm defined in [RFC7915]. NAT64 translators can operate in stateful ([RFC6144]) or stateless mode.
 This document uses "NAT64" as a generalized term for a translator which uses the algorith defined in [RFC7915] and operates within a framework for IPv4/IPv6 translation described in [RFC6144].
 
 PREF64 (or Pref64::/n, or NAT64 prefix): An IPv6 prefix used for IPv6 address synthesis and for network addresses and protocols translation from IPv6 clients to IPv4 servers using the algorithm defined in [RFC6052].

--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -121,7 +121,7 @@ VPN applications may override the endpoint's DNS configuration, for example, by 
 These enterprise DNS servers typically lack DNS64 functionality and therefore cannot provide information about the PREF64 used within the local network.
 Consequently, this prevents the endpoint from discovering the necessary PREF64, negatively impacting its connectivity on IPv6-only networks.
 
-If both the network-provided DNS64 and the endpoint's resolver happen to utilize the Well-Known Prefix (64:ff9b::/96, [RFC6052]), the endpoint would discover a PREF64 that's valid for the current network.
+If both the network-provided DNS64 and the endpoint's resolver happen to utilize the Well-Known Prefix (64:ff9b::/96, [RFC6052]), the endpoint would end up using a PREF64 that's valid for the current network.
 However, if the endpoint changes its network attachment, it can't detect if the new network lacks NAT64 entirely or uses a network-specific NAT64 prefix (NSP, [RFC6144]).
 
 ## Network Stack Initialization Delay

--- a/draft-ietf-v6ops-prefer8781.md
+++ b/draft-ietf-v6ops-prefer8781.md
@@ -48,6 +48,7 @@ informative:
   RFC6052:
   RFC6144:
   RFC6146:
+  RFC7225:
   RFC7915:
   RFC6147:
   RFC6877:
@@ -71,9 +72,10 @@ Devices translating between IPv4 and IPv6 packet headers [RFC7915] use a NAT64 p
 When a network provides NAT64, it is advantageous for endpoints to acquire the network's NAT64 prefixes (PREF64).
 Discovering the PREF64 enables endpoints to:
 
-  * Implement the customer-side translator (CLAT) function of the 464XLAT architecture [RFC6877];
-  * Translate IPv4 literals to IPv6 literals (Section 7.1 of [RFC8305]);
+  * Implement the customer-side translator (CLAT) function of the 464XLAT architecture [RFC6877].
+  * Translate IPv4 literals to IPv6 literals (Section 7.1 of [RFC8305]).
   * Perform local DNS64 [RFC6147] functions.
+  * Support applications relying on IPv4 address referral (Section 3.2.2 of [RFC7225]).
 
 Dynamic PREF64 discovery is useful to keep the NAT64 prefix configuration up-to-date, particularly for unmanaged endpoints or endpoints which move between networks.
 [RFC7050] introduces the first DNS64-based mechanism for PREF64 discovery based on [RFC7051] analysis.


### PR DESCRIPTION
- Explaining WKP/NSP, removing "by coincidence"
- Expanding NAT64 definition and renaming the section to "Terminology"
- Adding a reference to RFC7225 and application referrals to the Introduction